### PR TITLE
Generalising L2 ball projection w.r.t. vector format

### DIFF
--- a/pyunlocbox/functions.py
+++ b/pyunlocbox/functions.py
@@ -527,7 +527,7 @@ class proj_b2(proj):
 
             # Initialization.
             sol = x
-            u = np.zeros(np.size(self.y))
+            u = np.zeros(np.shape(self.y))
             if self.method is 'FISTA':
                 v_last = u
                 t_last = 1.


### PR DESCRIPTION
By using the shape property rather than the size property of the y
vector in the initialisation in `proj_b2`, the toolbox can also work on
vectors defined two-dimensionally as columns (e.g., shape (10,1) in
addition to (10,) ).