### PR TITLE
Fixed integer division bug in generalized_forward_backward

### DIFF
--- a/pyunlocbox/solvers.py
+++ b/pyunlocbox/solvers.py
@@ -525,7 +525,7 @@ class generalized_forward_backward(solver):
 
         if len(self.weight) == 0:
             if len(self.f1):
-                self.weight = np.repeat(1/len(self.f1), len(self.f1))
+                self.weight = np.repeat(1./len(self.f1), len(self.f1))
         elif len(self.weight) != len(self.f1):
             raise ValueError('GENERALIZED FORWARD BACKWARD: The number of\
                              element in weight is wrong')


### PR DESCRIPTION
There was a division in the calculation of `self.weight` in the `_pre`
function of the `generalized_forward_backward` solver that erroneously
resulted in 0 as a result of integer division when run in Python 2.7.x.
Fixed by changing the numerator `1` to float `1.`

I guess it is possible that this may have slipped through due to different handling of division in Python 3.x. I chose to fix this in what I consider the minimally intrusive way.