### PR TITLE
Fixed unsafe initialisation of `generalized_forward_backward`

### DIFF
--- a/pyunlocbox/solvers.py
+++ b/pyunlocbox/solvers.py
@@ -518,7 +518,7 @@ class generalized_forward_backward(solver):
                 self.f2.append(functions[ii])
             elif 'PROX' in functions[ii].cap(x0):
                 self.f1.append(functions[ii])
-                self.z.append(x0)
+                self.z.append(np.array(x0))
             else:
                 raise ValueError('SOLVER: There is a function without grad\
                                  and prox')


### PR DESCRIPTION
The initialisation of the `generalized_forward_backward` solver would
append the initialisation point `x0` to its internal data structures in
a way that would alter the original `x0`, causing it to be modified
externally upon return from the solver.
I have attempted to fix it by instead appending a copy of `x0` obtained
as a new NumPy array initialised with `x0` in the same "style" as the
initialisation is done in the `forward_backward` solver.