### PR TITLE
Acceleration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
       - texlive-latex-recommended
       - texlive-latex-extra
       - texlive-fonts-recommended
+      - latexmk
 
 install:
   - pip install --upgrade pip

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,112 @@
+============
+Contributing
+============
+
+Contributions are welcome, and they are greatly appreciated! Every
+little bit helps, and credit will always be given. 
+
+You can contribute in many ways:
+
+Types of Contributions
+----------------------
+
+Report Bugs
+~~~~~~~~~~~
+
+Report bugs at https://github.com/epfl-lts2/pyunlocbox/issues.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+~~~~~~~~
+
+Look through the GitHub issues for bugs. Anything tagged with "bug"
+is open to whoever wants to fix it.
+
+Implement Features
+~~~~~~~~~~~~~~~~~~
+
+Look through the GitHub issues for features. Anything tagged with "feature"
+is open to whoever wants to implement it.
+
+Write Documentation
+~~~~~~~~~~~~~~~~~~~
+
+PyGSP could always use more documentation, whether as part of the 
+official PyGSP docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+~~~~~~~~~~~~~~~
+
+The best way to send feedback is to file an issue at https://github.com/epfl-lts2/pyunlocbox/issues.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+Get Started!
+------------
+
+Ready to contribute? Here's how to set up `pyunlocbox` for local development.
+
+1. Fork the `pyunlocbox` repo on GitHub.
+2. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/pyunlocbox.git
+
+3. Install your local copy into a virtualenv. Assuming you have `virtualenvwrapper <https://virtualenvwrapper.readthedocs.org/en/latest/>`_ installed, this is how you set up your fork for local development::
+
+    $ mkvirtualenv pyunlocbox
+    $ cd pyunlocbox/
+    $ python setup.py develop
+
+Note: alternatively, the third step could be replaced by::
+
+    $ pip install -e .
+
+4. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+   
+   Now you can make your changes locally.
+
+5. For each new feature/bugfix you develop, please create a respective test case under pyunlocbox/pyunlocbox/tests/. It might be that you can just add a new test function to the existing test scripts, or that it makes more sense to create a new test script altogether. In the latter case, make sure to add a reference to the new test script test_all.py .
+
+6. When you're done making changes, check that your changes pass the tests, and, ideally flake8, by running the following commands from your local pyunlocbox directory::
+
+    $ make test
+    $ make lint
+   
+   Check the generated coverage report at pyunlocbox/htmlcov/index.html to make sure that the tests fully (or mostly) cover the changes you’ve introduced to the repository. If that’s not the case, add more test cases and repeat step 6.
+
+7. Commit your changes and push your branch to GitHub::
+
+    $ git add *
+    $ git commit -m "Your detailed description of your changes."
+    $ git push --set-upstream origin name-of-your-branch
+
+8. Submit a pull request through the GitHub website, but make sure to read the pull request guidelines below.
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.rst.
+
+3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6. Check 
+   https://travis-ci.org/epfl-lts2/pygsp/pull_requests
+   and make sure that the tests pass for all supported Python versions.
+

--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,11 @@ by a call to the solving function.
 >>> f2 = pyunlocbox.functions.dummy()
 >>> solver = pyunlocbox.solvers.forward_backward()
 >>> ret = pyunlocbox.solvers.solve([f1, f2], [0., 0, 0, 0], solver, atol=1e-5)
-Solution found after 8 iterations:
-    objective function f(sol) = 2.927052e-06
+Solution found after 9 iterations:
+    objective function f(sol) = 6.714385e-08
     stopping criterion: ATOL
 >>> ret['sol']
-array([ 3.99939034,  4.99923792,  5.99908551,  6.99893309])
+array([ 3.99990766,  4.99988458,  5.99986149,  6.99983841])
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Features
 
   * FISTA acceleration scheme
   * Backtracking based on a quadratic approximation of the objective
+  * Regularized nonlinear acceleration (RNA)
 
 Following is a typical usage example who solves an optimization problem
 composed by the sum of two convex functions. The functions and solver objects

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ array([ 3.99990766,  4.99988458,  5.99986149,  6.99983841])
 Installation
 ------------
 
-PyUnLocBox is continuously tested on Python 2.7, 3.3, 3.4 and 3.5.
+PyUnLocBox is continuously tested on Python 2.7, 3.4, 3.5, and 3.6.
 
 System-wide installation::
 

--- a/README.rst
+++ b/README.rst
@@ -6,18 +6,20 @@ PyUNLocBoX is a convex optimization toolbox using proximal splitting methods
 implemented in Python. It is a free software distributed under the BSD license
 and is a port of the Matlab UNLocBoX toolbox.
 
-.. image:: https://img.shields.io/travis/epfl-lts2/pyunlocbox.svg
-   :target: https://travis-ci.org/epfl-lts2/pyunlocbox
+.. only:: html
 
-.. image:: https://img.shields.io/coveralls/epfl-lts2/pyunlocbox.svg
-   :target: https://coveralls.io/github/epfl-lts2/pyunlocbox
+  .. image:: https://img.shields.io/travis/epfl-lts2/pyunlocbox.svg
+     :target: https://travis-ci.org/epfl-lts2/pyunlocbox
 
-.. image:: https://img.shields.io/pypi/v/pyunlocbox.svg
-   :target: https://pypi.python.org/pypi/pyunlocbox
+  .. image:: https://img.shields.io/coveralls/epfl-lts2/pyunlocbox.svg
+     :target: https://coveralls.io/github/epfl-lts2/pyunlocbox
 
-.. image:: https://img.shields.io/pypi/l/pyunlocbox.svg
+  .. image:: https://img.shields.io/pypi/v/pyunlocbox.svg
+     :target: https://pypi.python.org/pypi/pyunlocbox
 
-.. image:: https://img.shields.io/pypi/pyversions/pyunlocbox.svg
+  .. image:: https://img.shields.io/pypi/l/pyunlocbox.svg
+
+  .. image:: https://img.shields.io/pypi/pyversions/pyunlocbox.svg
 
 * Development : https://github.com/epfl-lts2/pyunlocbox
 * Documentation : https://pyunlocbox.readthedocs.io

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,11 @@ Features
   * TV-norm
   * Projection on the L2-ball
 
+* Acceleration schemes
+
+  * FISTA acceleration scheme
+  * Backtracking based on a quadratic approximation of the objective
+
 Following is a typical usage example who solves an optimization problem
 composed by the sum of two convex functions. The functions and solver objects
 are first instantiated with the desired parameters. The problem is then solved
@@ -52,11 +57,11 @@ by a call to the solving function.
 >>> f2 = pyunlocbox.functions.dummy()
 >>> solver = pyunlocbox.solvers.forward_backward()
 >>> ret = pyunlocbox.solvers.solve([f1, f2], [0., 0, 0, 0], solver, atol=1e-5)
-Solution found after 10 iterations:
-    objective function f(sol) = 7.460428e-09
+Solution found after 8 iterations:
+    objective function f(sol) = 2.927052e-06
     stopping criterion: ATOL
 >>> ret['sol']
-array([ 3.99996922,  4.99996153,  5.99995383,  6.99994614])
+array([ 3.99939034,  4.99923792,  5.99908551,  6.99893309])
 
 Installation
 ------------

--- a/doc/reference/acceleration.rst
+++ b/doc/reference/acceleration.rst
@@ -41,3 +41,11 @@ FISTA acceleration scheme with backtracking
     :members:
     :undoc-members:
     :show-inheritance:
+
+Regularized Nonlinear Acceleration (RNA)
+----------------------------------------
+
+.. autoclass:: pyunlocbox.acceleration.regularized_nonlinear
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/reference/acceleration.rst
+++ b/doc/reference/acceleration.rst
@@ -1,0 +1,43 @@
+============================
+Acceleration class hierarchy
+============================
+
+Acceleration scheme object interface
+------------------------------------
+
+.. autoclass:: pyunlocbox.acceleration.accel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Dummy acceleration scheme
+-------------------------
+
+.. autoclass:: pyunlocbox.acceleration.dummy
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Backtracking from quadratic approximation
+-----------------------------------------
+
+.. autoclass:: pyunlocbox.acceleration.backtracking
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+FISTA acceleration scheme
+-------------------------
+
+.. autoclass:: pyunlocbox.acceleration.fista
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+FISTA acceleration scheme with backtracking
+-------------------------------------------
+
+.. autoclass:: pyunlocbox.acceleration.fista_backtracking
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -36,6 +36,20 @@ Solvers module
 .. inheritance-diagram:: pyunlocbox.solvers
     :parts: 2
 
+Acceleration module
+-------------------
+
+.. toctree::
+    :hidden:
+
+    acceleration
+
+.. automodule:: pyunlocbox.acceleration
+
+.. inheritance-diagram:: pyunlocbox.acceleration
+    :parts: 2
+
+
 Operators module
 ----------------
 

--- a/doc/reference/solvers.rst
+++ b/doc/reference/solvers.rst
@@ -10,6 +10,14 @@ Solver object interface
     :undoc-members:
     :show-inheritance:
 
+Gradient descent algorithm
+--------------------------
+
+.. autoclass:: pyunlocbox.solvers.gradient_descent
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Forward-backward proximal splitting algorithm
 ---------------------------------------------
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -54,6 +54,16 @@
   publisher={IEEE}
 }
 
+@incollection{combettes:2011iq,
+author = {Combettes, Patrick L and Pesquet, Jean-Christophe},
+title = {{Proximal Splitting Methods in Signal Processing}},
+booktitle = {Fixed-Point Algorithms for Inverse Problems in Science and Engineering},
+year = {2011},
+pages = {185--212},
+publisher = {Springer New York},
+address = {New York, NY}
+}
+
 ----  Tutorials  ----
 
 @article{candes2007CSperfect,

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -76,3 +76,18 @@ address = {New York, NY}
   year={2007},
   publisher={IOP Publishing}
 }
+
+---- Acceleration ----
+
+@article{scieur2016,
+author = {Scieur, Damien and dAspremont, Alexandre and Bach, Francis},
+title = {{Regularized Nonlinear Acceleration}},
+journal = {arxiv.org},
+year = {2016},
+eprint = {1606.04133},
+eprinttype = {arxiv},
+eprintclass = {math.OC},
+pages = {arXiv:1606.04133},
+month = jun
+}
+

--- a/doc/tutorials/compressed_sensing_douglas_rachford.rst
+++ b/doc/tutorials/compressed_sensing_douglas_rachford.rst
@@ -19,8 +19,8 @@ reconstruction. See :cite:`candes2007CSperfect` for details.
 .. plot::
    :context: reset
 
-   >>> n = 5000
-   >>> S = 100
+   >>> n = 900
+   >>> S = 45
    >>> import numpy as np
    >>> m = int(np.ceil(S * np.log(n)))
    >>> print('Number of measurements: {}'.format(m))

--- a/doc/tutorials/compressed_sensing_douglas_rachford.rst
+++ b/doc/tutorials/compressed_sensing_douglas_rachford.rst
@@ -24,9 +24,9 @@ reconstruction. See :cite:`candes2007CSperfect` for details.
    >>> import numpy as np
    >>> m = int(np.ceil(S * np.log(n)))
    >>> print('Number of measurements: {}'.format(m))
-   Number of measurements: 852
+   Number of measurements: 307
    >>> print('Compression ratio: {:3.2f}'.format(float(n) / m))
-   Compression ratio: 5.87
+   Compression ratio: 2.93
 
 We generate a random measurement matrix `A`:
 
@@ -101,8 +101,8 @@ follows:
 
    >>> x0 = np.zeros(n)
    >>> ret = solvers.solve([f1, f2], x0, solver, rtol=1e-4, maxit=300)
-   Solution found after 56 iterations:
-       objective function f(sol) = 7.590460e+00
+   Solution found after 43 iterations:
+       objective function f(sol) = 5.607407e+00
        stopping criterion: RTOL
 
 Let's display the results:

--- a/doc/tutorials/compressed_sensing_forward_backward.rst
+++ b/doc/tutorials/compressed_sensing_forward_backward.rst
@@ -119,7 +119,7 @@ instantiated as follows:
 
    >>> step = 0.5 / np.linalg.norm(A, ord=2)**2
    >>> from pyunlocbox import solvers
-   >>> solver = solvers.forward_backward(method='FISTA', step=step)
+   >>> solver = solvers.forward_backward(step=step)
 
 .. note:: A complete description of the constructor parameters and default
     values is given by the solver object
@@ -134,9 +134,9 @@ follows:
 
    >>> x0 = np.zeros(n)
    >>> ret = solvers.solve([f1, f2], x0, solver, rtol=1e-4, maxit=300)
-   Solution found after 152 iterations:
-       objective function f(sol) = 7.668195e+00
-       stopping criterion: RTOL
+   Solution found after 300 iterations:
+       objective function f(sol) = 1.401112e+01
+       stopping criterion: MAXIT
 
 .. note:: A complete description of the parameters, their default values and
     the returned values is given by the solving function

--- a/doc/tutorials/compressed_sensing_forward_backward.rst
+++ b/doc/tutorials/compressed_sensing_forward_backward.rst
@@ -134,9 +134,9 @@ follows:
 
    >>> x0 = np.zeros(n)
    >>> ret = solvers.solve([f1, f2], x0, solver, rtol=1e-4, maxit=300)
-   Solution found after 300 iterations:
-       objective function f(sol) = 1.401112e+01
-       stopping criterion: MAXIT
+   Solution found after 151 iterations:
+       objective function f(sol) = 7.668167e+00
+       stopping criterion: RTOL
 
 .. note:: A complete description of the parameters, their default values and
     the returned values is given by the solving function

--- a/doc/tutorials/reconstruction.rst
+++ b/doc/tutorials/reconstruction.rst
@@ -82,7 +82,7 @@ with
    :context:
 
    >>> from pyunlocbox import solvers
-   >>> solver = solvers.forward_backward(method='FISTA', step=0.5/tau)
+   >>> solver = solvers.forward_backward(step=0.5/tau)
 
 and the problem solved with
 
@@ -91,9 +91,9 @@ and the problem solved with
 
    >>> x0 = np.array(im_masked)  # Make a copy to preserve im_masked.
    >>> ret = solvers.solve([f1, f2], x0, solver, maxit=100)
-   Solution found after 94 iterations:
-       objective function f(sol) = 4.268147e+03
-       stopping criterion: RTOL
+   Solution found after 100 iterations:
+       objective function f(sol) = 2.745485e+04
+       stopping criterion: MAXIT
 
 Let's display the results:
 

--- a/doc/tutorials/reconstruction.rst
+++ b/doc/tutorials/reconstruction.rst
@@ -91,9 +91,9 @@ and the problem solved with
 
    >>> x0 = np.array(im_masked)  # Make a copy to preserve im_masked.
    >>> ret = solvers.solve([f1, f2], x0, solver, maxit=100)
-   Solution found after 100 iterations:
-       objective function f(sol) = 2.745485e+04
-       stopping criterion: MAXIT
+   Solution found after 93 iterations:
+       objective function f(sol) = 4.268861e+03
+       stopping criterion: RTOL
 
 Let's display the results:
 

--- a/doc/tutorials/simple.rst
+++ b/doc/tutorials/simple.rst
@@ -75,34 +75,38 @@ And finally solve the problem :
        objective = 1.40e+01
    Iteration 2 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 1.555556e+00
-       objective = 1.56e+00
+       norm_l2 evaluation: 2.963739e-01
+       objective = 2.96e-01
    Iteration 3 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 1.728395e-01
-       objective = 1.73e-01
+       norm_l2 evaluation: 7.902529e-02
+       objective = 7.90e-02
    Iteration 4 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 1.920439e-02
-       objective = 1.92e-02
+       norm_l2 evaluation: 5.752265e-02
+       objective = 5.75e-02
    Iteration 5 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 2.133821e-03
-       objective = 2.13e-03
+       norm_l2 evaluation: 5.142032e-03
+       objective = 5.14e-03
    Iteration 6 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 2.370912e-04
-       objective = 2.37e-04
+       norm_l2 evaluation: 1.553851e-04
+       objective = 1.55e-04
    Iteration 7 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 2.634347e-05
-       objective = 2.63e-05
+       norm_l2 evaluation: 5.498523e-04
+       objective = 5.50e-04
    Iteration 8 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 2.927052e-06
-       objective = 2.93e-06
-   Solution found after 8 iterations:
-       objective function f(sol) = 2.927052e-06
+       norm_l2 evaluation: 1.091372e-04
+       objective = 1.09e-04
+   Iteration 9 of forward_backward:
+       func evaluation: 0.000000e+00
+       norm_l2 evaluation: 6.714385e-08
+       objective = 6.71e-08
+   Solution found after 9 iterations:
+       objective function f(sol) = 6.714385e-08
        stopping criterion: ATOL
 
 The solving function returns several values, one is the found solution :
@@ -111,7 +115,7 @@ The solving function returns several values, one is the found solution :
    :context:
 
    >>> ret['sol']
-   array([ 3.99939034,  4.99923792,  5.99908551,  6.99893309])
+   array([ 3.99990766,  4.99988458,  5.99986149,  6.99983841])
 
 Another one is the value returned by each function objects at each iteration.
 As we passed two function objects (L2-norm and dummy), the `objective` is a 2

--- a/doc/tutorials/simple.rst
+++ b/doc/tutorials/simple.rst
@@ -68,7 +68,7 @@ And finally solve the problem :
    >>> ret = solvers.solve([f2, f1], x0, solver, atol=1e-5, verbosity='HIGH')
        func evaluation: 0.000000e+00
        norm_l2 evaluation: 1.260000e+02
-   INFO: Forward-backward method: FISTA
+   INFO: Forward-backward method
    Iteration 1 of forward_backward:
        func evaluation: 0.000000e+00
        norm_l2 evaluation: 1.400000e+01
@@ -79,38 +79,30 @@ And finally solve the problem :
        objective = 1.56e+00
    Iteration 3 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 3.293044e-02
-       objective = 3.29e-02
+       norm_l2 evaluation: 1.728395e-01
+       objective = 1.73e-01
    Iteration 4 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 8.780588e-03
-       objective = 8.78e-03
+       norm_l2 evaluation: 1.920439e-02
+       objective = 1.92e-02
    Iteration 5 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 6.391406e-03
-       objective = 6.39e-03
+       norm_l2 evaluation: 2.133821e-03
+       objective = 2.13e-03
    Iteration 6 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 5.713369e-04
-       objective = 5.71e-04
+       norm_l2 evaluation: 2.370912e-04
+       objective = 2.37e-04
    Iteration 7 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 1.726501e-05
-       objective = 1.73e-05
+       norm_l2 evaluation: 2.634347e-05
+       objective = 2.63e-05
    Iteration 8 of forward_backward:
        func evaluation: 0.000000e+00
-       norm_l2 evaluation: 6.109470e-05
-       objective = 6.11e-05
-   Iteration 9 of forward_backward:
-       func evaluation: 0.000000e+00
-       norm_l2 evaluation: 1.212636e-05
-       objective = 1.21e-05
-   Iteration 10 of forward_backward:
-       func evaluation: 0.000000e+00
-       norm_l2 evaluation: 7.460428e-09
-       objective = 7.46e-09
-   Solution found after 10 iterations:
-       objective function f(sol) = 7.460428e-09
+       norm_l2 evaluation: 2.927052e-06
+       objective = 2.93e-06
+   Solution found after 8 iterations:
+       objective function f(sol) = 2.927052e-06
        stopping criterion: ATOL
 
 The solving function returns several values, one is the found solution :
@@ -119,7 +111,7 @@ The solving function returns several values, one is the found solution :
    :context:
 
    >>> ret['sol']
-   array([ 3.99996922,  4.99996153,  5.99995383,  6.99994614])
+   array([ 3.99939034,  4.99923792,  5.99908551,  6.99893309])
 
 Another one is the value returned by each function objects at each iteration.
 As we passed two function objects (L2-norm and dummy), the `objective` is a 2

--- a/pyunlocbox/__init__.py
+++ b/pyunlocbox/__init__.py
@@ -31,5 +31,5 @@ assert solvers
 assert operators
 assert acceleration
 
-__version__ = '0.3'
+__version__ = '0.3.0'
 __release_date__ = '2017-07-01'

--- a/pyunlocbox/__init__.py
+++ b/pyunlocbox/__init__.py
@@ -14,17 +14,22 @@ The :mod:`pyunlocbox` package is divided into the following modules :
   hierarchy and the solving function
 * :mod:`pyunlocbox.functions`: functions to be passed to the solvers, implement
   the functions class hierarchy
+* :mod:`pyunlocbox.operators`: useful operators to be passed to the functions
+* :mod:`pyunlocbox.acceleration`: acceleration schemes to be passed to the
+  solvers, implement the acceleration class hierarchy
 """
 
 # When importing the toolbox, you surely want these modules.
 from pyunlocbox import functions
 from pyunlocbox import solvers
 from pyunlocbox import operators
+from pyunlocbox import acceleration
 
 # Silence the code checker warning about unused symbols.
 assert functions
 assert solvers
 assert operators
+assert acceleration
 
-__version__ = '0.2.1'
-__release_date__ = '2014-08-20'
+__version__ = '0.2.3'
+__release_date__ = '2017-07-01'

--- a/pyunlocbox/__init__.py
+++ b/pyunlocbox/__init__.py
@@ -31,5 +31,5 @@ assert solvers
 assert operators
 assert acceleration
 
-__version__ = '0.2.3'
+__version__ = '0.3'
 __release_date__ = '2017-07-01'

--- a/pyunlocbox/acceleration.py
+++ b/pyunlocbox/acceleration.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+
+r"""
+This module implements acceleration schemes for use with the :class:`solver`
+classes. Pass a given acceleration object as an argument to your chosen solver
+during its initialization so that the solver can use it. The base class
+:class:`acceleration` defines the interface of all acceleration objects. The
+specialized acceleration objects inherit from it and implement the class
+methods. The following acceleration schemes are included :
+
+* :class:`dummy`: Dummy acceleration scheme. Does nothing.
+* :class:`backtracking`: Backtracking line search.
+* :class:`fista`: FISTA acceleration scheme.
+* :class:`fista_backtracking`: FISTA with backtracking.
+
+"""
+
+import numpy as np
+
+
+class accel(object):
+    r"""
+    Defines the acceleration scheme object interface.
+
+    This class defines the interface of an acceleration scheme object intended
+    to be passed to a solver inheriting from
+    :class:`pyunlocbox.solvers.solver`. It is intended to be a base class for
+    standard acceleration schemes which will implement the required methods.
+    It can also be instantiated by user code and dynamically modified for
+    rapid testing. This class also defines the generic attributes of all
+    acceleration scheme objects.
+
+    """
+
+    def __init__(self):
+        pass
+
+    def pre(self, functions, x0):
+        """
+        Pre-processing specific to the acceleration scheme.
+
+        Gets called when :func:`pyunlocbox.solvers.solve` starts running.
+        """
+        self.sol = np.asarray(x0)
+        self._pre(functions, self.sol)
+
+    def _pre(self, functions, x0):
+        raise NotImplementedError("Class user should define this method.")
+
+    def update_step(self, solver, objective, niter):
+        """
+        Update the step size for the next iteration.
+
+        Parameters
+        ----------
+        solver : pyunlocbox.solvers.solver
+            Solver on which to act.
+        objective : list of floats
+            List of evaluations of the objective function since the beginning
+            of the iterative process.
+        niter : int
+            Current iteration number.
+
+        Returns
+        -------
+        float
+            Updated step size.
+        """
+        return self._update_step(self, solver, objective, niter)
+
+    def _update_step(self, solver, objective, niter):
+        raise NotImplementedError("Class user should define this method.")
+
+    def update_sol(self, solver, objective, niter):
+        """
+        Update the solution point for the next iteration.
+
+        Parameters
+        ----------
+        solver : pyunlocbox.solvers.solver
+            Solver on which to act.
+        objective : list of floats
+            List of evaluations of the objective function since the beginning
+            of the iterative process.
+        niter : int
+            Current iteration number.
+
+        Returns
+        -------
+        array_like
+            Updated solution point.
+        """
+        return self._update_sol(self, solver, objective, niter)
+
+    def _update_sol(self, solver, objective, niter):
+        raise NotImplementedError("Class user should define this method.")
+
+    def post(self):
+        """
+        Post-processing specific to the acceleration scheme.
+
+        Mainly used to delete references added during initialization so that
+        the garbage collector can free the memory. Gets called when
+        :func:`pyunlocbox.solvers.solve` finishes running.
+        """
+        self._post()
+        del self.sol
+
+    def _post(self):
+        raise NotImplementedError("Class user should define this method.")
+
+
+class dummy(accel):
+    r""" Dummy acceleration scheme. """
+
+    def _pre(self, functions, x0):
+        pass
+
+    def _update_step(self, solver, objective, niter):
+        return solver.step
+
+    def _update_sol(self, solver, objective, niter):
+        return solver.sol
+
+    def _post(self):
+        pass
+
+
+class backtracking(dummy):
+    r"""
+    Backtracking based on a local quadratic approximation of the objective.
+
+    Parameters
+    ----------
+    eta : float
+        A number between 0 and 1 representing the ratio of the geometric
+        sequence formed by successive step sizes. In other words, it
+        establishes the relation `step_new = eta * step_old`. Default is 0.5.
+
+    Notes
+    -----
+    This is the backtracking strategy proposed in the original FISTA paper,
+    :cite:`beck2009FISTA`.
+    """
+
+    def __init__(self, eta=0.5, *args, **kwargs):
+        if (eta > 1) or (eta <= 0):
+            raise ValueError("eta must be between 0 and 1.")
+        self.eta = eta
+        super(backtracking, self).__init__(*args, **kwargs)
+
+    def _pre(self, functions, x0):
+        self.smooth_funs = []  # Smooth functions.
+        for f in functions:
+            if 'GRAD' in f.cap(x0):
+                self.smooth_funs.append(f)
+
+    def _update_step(self, solver, objective, niter):
+        """
+        Notes
+        -----
+        TODO: For now we're recomputing gradients in order to evaluate the
+        backtracking criterion. In the future, it might be interesting to
+        think of some design changes so that this function has access to the
+        gradients directly.
+        """
+        valp = 0
+        valn = objective[-1]
+        grad = np.zeros(self.sol.shape)
+        for f in self.smooth_funs:
+            valp += f.eval(solver.sol)
+            grad += f.grad(self.sol)
+
+        while (2 * solver.step *
+               (valp - valn - np.dot(solver.sol - self.sol, grad)) <
+                np.sum((solver.sol - self.sol)**2)):
+            solver.step *= self.eta
+            solver._algo()
+            valp = np.sum([f.eval(solver.sol) for f in self.smooth_funs])
+
+        return solver.step
+
+    def _post(self):
+        del self.smooth_funs
+
+
+class fista(accel):
+    r"""
+    Acceleration scheme for forward-backward solvers.
+
+    Notes
+    -----
+    This is the acceleration scheme proposed in the original FISTA paper,
+    :cite:`beck2009FISTA`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.t = 1.
+        super(fista, self).__init__(*args, **kwargs)
+
+    def update_sol(self, solver, objective, niter):
+        self.t = 1. if niter == 1 else self.t  # Restart variable t if needed
+        t = 1. + np.sqrt(1. + 4. * self.t**2) / 2.
+        y = solver.sol + ((self.t - 1) / t) * (solver.sol - self.sol)
+        self.t = t
+        self.sol[:] = solver.sol
+        return y
+
+
+class fista_backtracking(backtracking, fista):
+    r"""
+    Acceleration scheme with acktracking for forward-backward solvers.
+
+    Notes
+    -----
+    This is the acceleration scheme and backtracking strategy proposed in the
+    original FISTA paper, :cite:`beck2009FISTA`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        backtracking.__init__(self, *args, **kwargs)
+        fista.__init__(self, *args, **kwargs)

--- a/pyunlocbox/acceleration.py
+++ b/pyunlocbox/acceleration.py
@@ -329,8 +329,8 @@ class regularized_nonlinear(dummy):
     >>> params = {'rtol':0, 'maxit':200, 'verbosity':'NONE'}
     >>> ret = solvers.solve([f, fd], x0, solver, **params)
     >>> pctdiff = 100*np.sum((xstar - ret['sol'])**2)/np.sum(xstar**2)
-    >>> print('Difference: {0:.2f}%'.format(pctdiff))
-    Difference: 1.32%
+    >>> print('Difference: {0:.1f}%'.format(pctdiff))
+    Difference: 1.3%
 
     """
 

--- a/pyunlocbox/functions.py
+++ b/pyunlocbox/functions.py
@@ -25,12 +25,14 @@ inherit from it implement the methods. These classes include :
     :meth:`_eval` and :meth:`_prox` methods.
 """
 
-from time import time
-import numpy as np
-from copy import deepcopy
-from scipy.optimize import minimize
+from __future__ import division
 
+import numpy as np
+
+from copy import deepcopy
 from pyunlocbox import operators as op
+from scipy.optimize import minimize
+from time import time
 
 
 def _soft_threshold(z, T, handle_complex=True):
@@ -844,8 +846,7 @@ class proj_b2(proj):
             tmp1 = self.A(x) - self.y()
             with np.errstate(divide='ignore', invalid='ignore'):
                 # Avoid 'division by zero' warning
-                scale = np.true_divide(self.epsilon,
-                                       np.sqrt(np.sum(tmp1 * tmp1, axis=0)))
+                scale = self.epsilon / np.sqrt(np.sum(tmp1 * tmp1, axis=0))
             tmp2 = tmp1 * np.minimum(1, scale)  # Scaling.
             sol = x + self.At(tmp2 - tmp1) / self.nu
             crit = 'TOL'

--- a/pyunlocbox/functions.py
+++ b/pyunlocbox/functions.py
@@ -79,6 +79,18 @@ def _soft_threshold(z, T, handle_complex=True):
     return sz
 
 
+def _prox_star(func, z, T):
+    r"""
+    Proximity operator of the convex conjugate of a function.
+
+    Notes
+    -----
+    Based on the Moreau decomposition of a vector w.r.t. a convex function.
+
+    """
+    return z - T * func.prox(z / T, 1 / T)
+
+
 class func(object):
     r"""
     This class defines the function object interface.
@@ -830,7 +842,10 @@ class proj_b2(proj):
         # Tight frame.
         if self.tight:
             tmp1 = self.A(x) - self.y()
-            scale = self.epsilon / np.sqrt(np.sum(tmp1 * tmp1, axis=0))
+            with np.errstate(divide='ignore', invalid='ignore'):
+                # Avoid 'division by zero' warning
+                scale = np.true_divide(self.epsilon,
+                                       np.sqrt(np.sum(tmp1 * tmp1, axis=0)))
             tmp2 = tmp1 * np.minimum(1, scale)  # Scaling.
             sol = x + self.At(tmp2 - tmp1) / self.nu
             crit = 'TOL'

--- a/pyunlocbox/functions.py
+++ b/pyunlocbox/functions.py
@@ -102,8 +102,8 @@ class func(object):
         transpose of `A`.  If `A` is a function, default is `A`,
         :math:`At(x)=A(x)`.
     tight : bool, optional
-        ``True`` if `A` is a tight frame, ``False`` otherwise. Default is
-        ``True``.
+        ``True`` if `A` is a tight frame (semi-orthogonal linear transform),
+        ``False`` otherwise. Default is ``True``.
     nu : float, optional
         Bound on the norm of the operator `A`, i.e. :math:`\|A(x)\|^2 \leq \nu
         \|x\|^2`. Default is 1.
@@ -226,11 +226,19 @@ class func(object):
 
         Notes
         -----
-        This method is required by some solvers.
-
         The proximal operator is defined by
         :math:`\operatorname{prox}_{\gamma f}(x) = \operatorname{arg\,min}
         \limits_z \frac{1}{2} \|x-z\|_2^2 + \gamma f(z)`
+
+        This method is required by some solvers.
+
+        When the map A in the function construction is a tight frame
+        (semi-orthogonal linear transformation), we can use property (x) of
+        Table 10.1 in :cite:`combettes:2011iq` to compute the proximal
+        operator of the composition of A with the base function. Whenever
+        this is not the case, we have to resort to some iterative procedure,
+        which may be very inefficient.
+
         """
         return self._prox(np.asarray(x), T)
 
@@ -400,7 +408,7 @@ class norm_l1(norm):
             sol[:] = _soft_threshold(sol, gamma * self.nu * self.w) - sol
             sol[:] = x + self.At(sol) / self.nu
         else:
-            raise NotImplementedError('Not implemented for non tight frame.')
+            raise NotImplementedError('Not implemented for non-tight frame.')
         return sol
 
 

--- a/pyunlocbox/operators.py
+++ b/pyunlocbox/operators.py
@@ -128,7 +128,7 @@ def grad3d(x, **kwargs):
 
 
 def grad4d(x, **kwargs):
-    return grad(x, dim=4)
+    return grad(x, dim=4, **kwargs)
 
 
 def div(*args, **kwargs):

--- a/pyunlocbox/operators.py
+++ b/pyunlocbox/operators.py
@@ -115,22 +115,6 @@ def grad(x, dim=2, **kwargs):
         return dx, dy, dz, dt
 
 
-def grad1d(x, **kwargs):
-    return grad(x, dim=1, **kwargs)
-
-
-def grad2d(x, **kwargs):
-    return grad(x, dim=2, **kwargs)
-
-
-def grad3d(x, **kwargs):
-    return grad(x, dim=3, **kwargs)
-
-
-def grad4d(x, **kwargs):
-    return grad(x, dim=4, **kwargs)
-
-
 def div(*args, **kwargs):
     r"""
     Returns the divergence of the array

--- a/pyunlocbox/solvers.py
+++ b/pyunlocbox/solvers.py
@@ -422,12 +422,12 @@ class gradient_descent(solver):
     >>> f1 = functions.norm_l2(y=y)
     >>> f2 = functions.norm_l2(A=A)
     >>> solver = solvers.gradient_descent(step=0.5/(np.linalg.norm(A) + 1.))
-    >>> ret = solvers.solve([f1, f2], x0, solver, rtol=0)
-    Solution found after 200 iterations:
+    >>> ret = solvers.solve([f1, f2], x0, solver, rtol=1e-32)
+    Solution found after 58 iterations:
         objective function f(sol) = 1.043654e+02
-        stopping criterion: MAXIT
+        stopping criterion: RTOL
     >>> ret['sol']
-    array([ 0.28846154,  0.11538462,  1.23076923,  1.78846154])
+    array([ 0.28846153, 0.1153846, 1.23076922, 1.78846153])
 
     """
 

--- a/pyunlocbox/solvers.py
+++ b/pyunlocbox/solvers.py
@@ -429,8 +429,8 @@ class gradient_descent(solver):
     >>> params = {'rtol':0, 'maxit':14000, 'verbosity':'NONE'}
     >>> ret = solvers.solve([f, fd], x0, solver, **params)
     >>> pctdiff = 100*np.sum((xstar - ret['sol'])**2)/np.sum(xstar**2)
-    >>> print('Difference: {0:.2f}%'.format(pctdiff))
-    Difference: 1.32%
+    >>> print('Difference: {0:.1f}%'.format(pctdiff))
+    Difference: 1.3%
 
     """
 

--- a/pyunlocbox/solvers.py
+++ b/pyunlocbox/solvers.py
@@ -116,7 +116,7 @@ def solve(functions, x0, solver=None, atol=None, dtol=None, rtol=1e-3,
     INFO: Selected solver: forward_backward
         norm_l2 evaluation: 1.260000e+02
         dummy evaluation: 0.000000e+00
-    INFO: Forward-backward method: FISTA
+    INFO: Forward-backward method
     Iteration 1 of forward_backward:
         norm_l2 evaluation: 1.400000e+01
         dummy evaluation: 0.000000e+00
@@ -126,26 +126,30 @@ def solve(functions, x0, solver=None, atol=None, dtol=None, rtol=1e-3,
         dummy evaluation: 0.000000e+00
         objective = 1.56e+00
     Iteration 3 of forward_backward:
-        norm_l2 evaluation: 3.293044e-02
+        norm_l2 evaluation: 1.728395e-01
         dummy evaluation: 0.000000e+00
-        objective = 3.29e-02
+        objective = 1.73e-01
     Iteration 4 of forward_backward:
-        norm_l2 evaluation: 8.780588e-03
+        norm_l2 evaluation: 1.920439e-02
         dummy evaluation: 0.000000e+00
-        objective = 8.78e-03
-    Solution found after 4 iterations:
-        objective function f(sol) = 8.780588e-03
+        objective = 1.92e-02
+    Iteration 5 of forward_backward:
+        norm_l2 evaluation: 2.133821e-03
+        dummy evaluation: 0.000000e+00
+        objective = 2.13e-03
+    Solution found after 5 iterations:
+        objective function f(sol) = 2.133821e-03
         stopping criterion: ATOL
 
     Verify the stopping criterion (should be smaller than atol=1e-2):
 
     >>> np.linalg.norm(ret['sol'] - y)**2  # doctest:+ELLIPSIS
-    0.00878058...
+    0.00213382...
 
     Show the solution (should be close to y w.r.t. the L2-norm measure):
 
     >>> ret['sol']
-    array([ 4.03339154,  5.04173943,  6.05008732,  7.0584352 ])
+    array([ 3.98353909,  4.97942387,  5.97530864,  6.97119342])
 
     Show the used solver:
 
@@ -157,12 +161,12 @@ def solve(functions, x0, solver=None, atol=None, dtol=None, rtol=1e-3,
     >>> ret['crit']
     'ATOL'
     >>> ret['niter']
-    4
+    5
     >>> ret['time']  # doctest:+SKIP
     0.0012578964233398438
     >>> ret['objective']  # doctest:+NORMALIZE_WHITESPACE,+ELLIPSIS
-    [[126.0, 0], [13.99999999..., 0], [1.55555555..., 0],
-    [0.03293043..., 0], [0.00878058..., 0]]
+    [[126.0, 0], [13.99999999..., 0], [1.55555555..., 0], [0.17283950..., 0],
+    [0.01920438..., 0], [0.00213382..., 0]]
 
     """
 
@@ -386,10 +390,10 @@ class forward_backward(solver):
 
     Parameters
     ----------
-    accel : pyunlocbox.acceleration.accel
+    accel : :class:`pyunlocbox.acceleration.accel`
         Acceleration scheme to use.
-        Default is :class:`pyunlocbox.acceleration.fista`, which corresponds
-        to the 'FISTA' solver. Passing :class:`pyunlocbox.acceleration.dummy`
+        Default is :meth:`pyunlocbox.acceleration.fista`, which corresponds
+        to the 'FISTA' solver. Passing :meth:`pyunlocbox.acceleration.dummy`
         instead results in the ISTA solver. Note that while FISTA is much more
         time-efficient, it is less memory-efficient.
 
@@ -409,13 +413,13 @@ class forward_backward(solver):
     >>> x0 = np.zeros(len(y))
     >>> f1 = functions.norm_l2(y=y)
     >>> f2 = functions.dummy()
-    >>> solver = solvers.forward_backward(method='FISTA', step=0.5)
+    >>> solver = solvers.forward_backward(step=0.5)
     >>> ret = solvers.solve([f1, f2], x0, solver, atol=1e-5)
     Solution found after 12 iterations:
-        objective function f(sol) = 4.135992e-06
+        objective function f(sol) = 7.510185e-06
         stopping criterion: ATOL
     >>> ret['sol']
-    array([ 3.99927529,  4.99909411,  5.99891293,  6.99873176])
+    array([ 3.99902344,  4.9987793 ,  5.99853516,  6.99829102])
 
     """
 
@@ -665,7 +669,8 @@ class primal_dual(solver):
             self.dual_sol = self.d0
 
     def _post(self):
-        del self.dual_sol, self.d0
+        self.d0 = None
+        del self.dual_sol
 
 
 class mlfbf(primal_dual):
@@ -791,7 +796,7 @@ class projection_based(primal_dual):
 
     """
 
-    def __init__(self, lambda_=1, *args, **kwargs):
+    def __init__(self, lambda_=1., *args, **kwargs):
         super(projection_based, self).__init__(*args, **kwargs)
         self.lambda_ = lambda_
 

--- a/pyunlocbox/tests/test_acceleration.py
+++ b/pyunlocbox/tests/test_acceleration.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test suite for the acceleration module of the pyunlocbox package.
+"""
+
+import unittest
+import numpy as np
+import numpy.testing as nptest
+from pyunlocbox import functions, solvers, acceleration
+
+
+class FunctionsTestCase(unittest.TestCase):
+
+    def test_forward_backward_fista(self):
+        """
+        Test forward-backward splitting solver with fista acceleration,
+        solving problems with L1-norm, L2-norm, and dummy functions.
+        """
+        y = [4., 5., 6., 7.]
+        solver = solvers.forward_backward(accel=acceleration.fista())
+        param = {'solver': solver, 'rtol': 1e-6, 'verbosity': 'NONE'}
+
+        # L2-norm prox and dummy gradient.
+        f1 = functions.norm_l2(y=y)
+        f2 = functions.dummy()
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 35)
+
+        # Dummy prox and L2-norm gradient.
+        f1 = functions.dummy()
+        f2 = functions.norm_l2(y=y, lambda_=0.6)
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 25)
+
+        # L2-norm prox and L2-norm gradient.
+        f1 = functions.norm_l2(y=y)
+        f2 = functions.norm_l2(y=y)
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 35)
+
+        # L1-norm prox and dummy gradient.
+        f1 = functions.norm_l1(y=y)
+        f2 = functions.dummy()
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 8)
+
+        # Dummy prox and L1-norm gradient. As L1-norm possesses no gradient,
+        # the algorithm exchanges the functions : exact same solution.
+        f1 = functions.dummy()
+        f2 = functions.norm_l1(y=y)
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 8)
+
+        # L1-norm prox and L1-norm gradient. L1-norm possesses no gradient.
+        f1 = functions.norm_l1(y=y)
+        f2 = functions.norm_l1(y=y)
+        self.assertRaises(ValueError, solvers.solve,
+                          [f1, f2], np.zeros(len(y)), **param)
+
+        # L1-norm prox and L2-norm gradient.
+        f1 = functions.norm_l1(y=y, lambda_=1.0)
+        f2 = functions.norm_l2(y=y, lambda_=0.8)
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 4)
+
+    def test_forward_backward_fista_backtracking(self):
+        """
+        Test forward-backward splitting solver with fista acceleration and
+        backtracking, solving problems with L1-norm, L2-norm, and dummy
+        functions.
+        """
+        y = [4., 5., 6., 7.]
+        solver = solvers.forward_backward(
+            accel=acceleration.fista_backtracking())
+        param = {'solver': solver, 'rtol': 1e-6, 'verbosity': 'NONE'}
+
+        # L2-norm prox and dummy gradient.
+        f1 = functions.norm_l2(y=y)
+        f2 = functions.dummy()
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 35)
+
+        # L1-norm prox and L2-norm gradient.
+        f1 = functions.norm_l1(y=y, lambda_=1.0)
+        f2 = functions.norm_l2(y=y, lambda_=0.8)
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 4)
+
+    def test_acceleration_comparison(self):
+        """
+        Test that all solvers return the same and correct solution.
+        """
+
+        # Convex functions.
+        y = [1, 0, 0.1, 8, -6.5, 0.2, 0.004, 0.01]
+        sol = [0.75, 0, 0, 7.75, -6.25, 0, 0, 0]
+        w1, w2 = .8, .4
+        f1 = functions.norm_l2(y=y, lambda_=w1 / 2.)  # Smooth.
+        f2 = functions.norm_l1(lambda_=w2 / 2.)       # Non-smooth.
+
+        # Solvers.
+        L = w1  # Lipschitz continuous gradient.
+        step = 1. / L
+        slvs = []
+        slvs.append(solvers.forward_backward(accel=acceleration.dummy(),
+                                             step=step))
+        slvs.append(solvers.forward_backward(accel=acceleration.fista(),
+                                             step=step))
+        slvs.append(solvers.forward_backward(
+            accel=acceleration.fista_backtracking(), step=step))
+
+        # Compare solutions.
+        params = {'rtol': 1e-14, 'verbosity': 'NONE', 'maxit': 1e4}
+        niters = [2, 2, 2]
+        for solver, niter in zip(slvs, niters):
+            x0 = np.zeros(len(y))
+            ret = solvers.solve([f1, f2], x0, solver, **params)
+            nptest.assert_allclose(ret['sol'], sol)
+            self.assertEqual(ret['niter'], niter)
+            self.assertIs(ret['sol'], x0)  # The initial value was modified.
+
+
+suite = unittest.TestLoader().loadTestsFromTestCase(FunctionsTestCase)

--- a/pyunlocbox/tests/test_all.py
+++ b/pyunlocbox/tests/test_all.py
@@ -20,6 +20,14 @@ def gen_recursive_file(root, ext):
 
 def test_docstrings(root, ext):
     files = list(gen_recursive_file(root, ext))
+
+    """ The following snippet removes from the doctest list any files which
+    might be problematic, e.g., files that cause build timeout in TracisCI.
+    """
+    keyword_filter = ['compressed_sensing_douglas_rachford']
+    files = [elem for elem in files
+             if not any(word in elem for word in keyword_filter)]
+
     return doctest.DocFileSuite(*files, module_relative=False)
 
 

--- a/pyunlocbox/tests/test_all.py
+++ b/pyunlocbox/tests/test_all.py
@@ -23,10 +23,11 @@ def test_docstrings(root, ext):
 
     """ The following snippet removes from the doctest list any files which
     might be problematic, e.g., files that cause build timeout in TracisCI.
-    """
+
     keyword_filter = ['compressed_sensing_douglas_rachford']
     files = [elem for elem in files
              if not any(word in elem for word in keyword_filter)]
+    """
 
     return doctest.DocFileSuite(*files, module_relative=False)
 

--- a/pyunlocbox/tests/test_all.py
+++ b/pyunlocbox/tests/test_all.py
@@ -5,7 +5,7 @@
 Test suite for the pyunlocbox package.
 """
 
-from . import test_functions, test_operators, test_solvers
+from . import test_functions, test_operators, test_solvers, test_acceleration
 import unittest
 import doctest
 import os
@@ -27,6 +27,7 @@ suites = []
 suites.append(test_functions.suite)
 suites.append(test_operators.suite)
 suites.append(test_solvers.suite)
+suites.append(test_acceleration.suite)
 suites.append(test_docstrings('pyunlocbox', '.py'))
 suites.append(test_docstrings('.', '.rst'))
 suite = unittest.TestSuite(suites)

--- a/pyunlocbox/tests/test_all.py
+++ b/pyunlocbox/tests/test_all.py
@@ -22,7 +22,7 @@ def test_docstrings(root, ext):
     files = list(gen_recursive_file(root, ext))
 
     """ The following snippet removes from the doctest list any files which
-    might be problematic, e.g., files that cause build timeout in TracisCI.
+    might be problematic, e.g., files that cause build timeout in TravisCI.
 
     keyword_filter = ['compressed_sensing_douglas_rachford']
     files = [elem for elem in files

--- a/pyunlocbox/tests/test_functions.py
+++ b/pyunlocbox/tests/test_functions.py
@@ -26,9 +26,11 @@ class FunctionsTestCase(unittest.TestCase):
         self.assertRaises(NotImplementedError, f.eval, x)
         self.assertRaises(NotImplementedError, f.prox, x, T)
         self.assertRaises(NotImplementedError, f.grad, x)
-        f.eval = lambda x: x**2 - 5
-        f.grad = lambda x: 2 * x
-        f.prox = lambda x, T: x + T
+        self.assertEqual(len(f.cap(x)), 0)
+        # Set up but never used:
+        # f.eval = lambda x: x**2 - 5
+        # f.grad = lambda x: 2 * x
+        # f.prox = lambda x, T: x + T
 
         def assert_equivalent(param1, param2):
             x = [[7, 8, 9], [10, 324, -45], [-7, -.2, 5]]
@@ -149,6 +151,11 @@ class FunctionsTestCase(unittest.TestCase):
         nptest.assert_array_equal(f.prox(np.array([[1, -4], [5, -2]]), 1),
                                   [[0, -1], [2, 0]])
 
+        f = functions.norm_l1(tight=False)
+        x = np.ones((4,))
+        T = 0.5
+        self.assertRaises(NotImplementedError, f.prox, x, T)
+
     def test_norm_nuclear(self):
         """
         Test the norm_nuclear derived class.
@@ -169,15 +176,17 @@ class FunctionsTestCase(unittest.TestCase):
         """
         # Test Matrices initialization
         # test for a 1dim matrice (testing with a 5)
-        mat1d = np.arange(5) + 1
+        # mat1d = np.arange(5) + 1
         # test for a 2dim matrice (testing with a 2x4)
         mat2d = np.array([[2, 3, 0, 1], [22, 1, 4, 5]])
         # test for a 3 dim matrice (testing with a 2x3x2)
         mat3d = np.arange(1, stop=13).reshape(2, 2, 3).transpose((1, 2, 0))
         # test for a 4dim matrice (2x3x2x2)
-        mat4d = np.arange(1, stop=25).reshape(2, 2, 2, 3).transpose((2, 3, 1, 0))
+        # mat4d = np.arange(1, stop=25).reshape(2, 2, 2, 3)
+        # mat4d = mat4d.transpose((2, 3, 1, 0))
         # test for a 5dim matrice (2x2x3x2x2)
-        mat5d = np.arange(1, stop=49).reshape(2, 2, 3, 2, 2).transpose((3, 4, 2, 1, 0))
+        # mat5d = np.arange(1, stop=49).reshape(2, 2, 3, 2, 2)
+        # mat5d = mat5d.transpose((3, 4, 2, 1, 0))
 
         # Test for evals
         def test_eval():
@@ -197,7 +206,8 @@ class FunctionsTestCase(unittest.TestCase):
             nptest.assert_array_equal(xeval, f.eval(mat2d))
             f = functions.norm_tv(dim=2, wx=0.5, wy=2)
             xeval = np.array([71.1092])
-            nptest.assert_array_equal(xeval, np.around(f.eval(mat2d), decimals=4))
+            nptest.assert_array_equal(
+                xeval, np.around(f.eval(mat2d), decimals=4))
 
             # test with 3d matrices (2x3x2)
             # test without weight
@@ -211,11 +221,13 @@ class FunctionsTestCase(unittest.TestCase):
             # test with weights
             f = functions.norm_tv(dim=2, wx=2, wy=3)
             sol = np.sum(np.array([25.4164, 25.4164]))
-            nptest.assert_array_equal(sol, np.around(f.eval(mat3d), decimals=4))
+            nptest.assert_array_equal(
+                sol, np.around(f.eval(mat3d), decimals=4))
 
             f = functions.norm_tv(dim=3, wx=2, wy=3, wz=.5)
             xeval = np.array([58.3068])
-            nptest.assert_array_equal(xeval, np.around(f.eval(mat3d), decimals=4))
+            nptest.assert_array_equal(
+                xeval, np.around(f.eval(mat3d), decimals=4))
 
         # Test for prox
         def test_prox():
@@ -355,6 +367,9 @@ class FunctionsTestCase(unittest.TestCase):
         f.method = 'ISTA'
         sol_ista = f.prox(x, 0)
         assert np.allclose(sol_fista, sol_ista, rtol=1e-3)
+
+        f.method = 'NOT_A_VALID_METHOD'
+        self.assertRaises(ValueError, f.prox, x, 0)
 
     def test_independent_problems(self):
 

--- a/pyunlocbox/tests/test_operators.py
+++ b/pyunlocbox/tests/test_operators.py
@@ -20,28 +20,29 @@ class OperatorsTestCase(unittest.TestCase):
         mat2d = np.array([[2, 3, 0, 1], [22, 1, 4, 5]])
         mat3d = np.arange(1, 13).reshape(2, 2, 3).transpose((1, 2, 0))
         mat4d = np.arange(1, 25).reshape(2, 2, 2, 3).transpose((2, 3, 1, 0))
-        mat5d = np.arange(1, 49).reshape(2, 2, 3, 2, 2).transpose((3, 4, 2, 1, 0))
+        mat5d = np.arange(1, 49).reshape(2, 2, 3, 2, 2)
+        mat5d = mat5d.transpose((3, 4, 2, 1, 0))
 
         # 1D without weights.
-        dx = operators.grad(mat1d, dim=1)
+        dx = operators.grad1d(mat1d)
         nptest.assert_array_equal(np.array([1, 1, 1, 1, 0]), dx)
 
         # 2D without weights.
         mat_dx = np.array([[20, -2, 4, 4], [0, 0, 0, 0]])
         mat_dy = np.array([[1, -3, 1, 0], [-21, 3, 1, 0]])
-        dx, dy = operators.grad(mat2d, dim=2)
+        dx, dy = operators.grad2d(mat2d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
 
         # 2D with weights.
-        dx, dy = operators.grad(mat2d, dim=2, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy = operators.grad2d(mat2d, wx=2, wy=0.5, wz=3, wt=2)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         nptest.assert_array_equal(mat_dx_w, dx)
         nptest.assert_array_equal(mat_dy_w, dy)
 
         # 3D without weights.
-        dx = operators.grad(mat3d, dim=1)
+        dx = operators.grad1d(mat3d)
         mat_dx = np.array([[[3, 3], [3, 3], [3, 3]],
                            [[0, 0], [0, 0], [0, 0]]])
         mat_dy = np.array([[[1, 1], [1, 1], [0, 0]],
@@ -49,16 +50,16 @@ class OperatorsTestCase(unittest.TestCase):
         mat_dz = np.array([[[6, 0], [6, 0], [6, 0]],
                            [[6, 0], [6, 0], [6, 0]]])
         nptest.assert_array_equal(mat_dx, dx)
-        dx, dy = operators.grad(mat3d, dim=2)
+        dx, dy = operators.grad2d(mat3d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
-        dx, dy, dz = operators.grad(mat3d, dim=3)
+        dx, dy, dz = operators.grad3d(mat3d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
 
         # 3D with weights.
-        dx, dy, dz = operators.grad(mat3d, dim=3, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy, dz = operators.grad3d(mat3d, wx=2, wy=0.5, wz=3, wt=2)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         mat_dz_w = mat_dz * 3
@@ -91,23 +92,23 @@ class OperatorsTestCase(unittest.TestCase):
                            [[[12, 0], [12, 0]],
                             [[12, 0], [12, 0]],
                             [[12, 0], [12, 0]]]])
-        dx = operators.grad(mat4d, dim=1)
+        dx = operators.grad1d(mat4d)
         nptest.assert_array_equal(mat_dx, dx)
-        dx, dy = operators.grad(mat4d, dim=2)
+        dx, dy = operators.grad2d(mat4d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
-        dx, dy, dz = operators.grad(mat4d, dim=3)
+        dx, dy, dz = operators.grad3d(mat4d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
-        dx, dy, dz, dt = operators.grad(mat4d, dim=4)
+        dx, dy, dz, dt = operators.grad4d(mat4d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
         nptest.assert_array_equal(mat_dt, dt)
 
         # 4D with weights.
-        dx, dy, dz, dt = operators.grad(mat4d, dim=4, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy, dz, dt = operators.grad4d(mat4d, wx=2, wy=0.5, wz=3, wt=2)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         mat_dz_w = mat_dz * 3
@@ -166,23 +167,23 @@ class OperatorsTestCase(unittest.TestCase):
                             [[[12, 12], [0, 0]],
                              [[12, 12], [0, 0]],
                              [[12, 12], [0, 0]]]]])
-        dx = operators.grad(mat5d, dim=1)
+        dx = operators.grad1d(mat5d)
         nptest.assert_array_equal(mat_dx, dx)
-        dx, dy = operators.grad(mat5d, dim=2)
+        dx, dy = operators.grad2d(mat5d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
-        dx, dy, dz = operators.grad(mat5d, dim=3)
+        dx, dy, dz = operators.grad3d(mat5d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
-        dx, dy, dz, dt = operators.grad(mat5d, dim=4)
+        dx, dy, dz, dt = operators.grad4d(mat5d)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
         nptest.assert_array_equal(mat_dt, dt)
 
         # 5D with weights.
-        dx, dy, dz, dt = operators.grad(mat5d, dim=4, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy, dz, dt = operators.grad4d(mat5d, wx=2, wy=0.5, wz=3, wt=2)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         mat_dz_w = mat_dz * 3
@@ -193,16 +194,21 @@ class OperatorsTestCase(unittest.TestCase):
         nptest.assert_array_equal(mat_dt_w, dt)
 
     def test_div(self):
+        # Sanity check
+        self.assertRaises(ValueError, operators.div)
+
         # Divergence tests
         # test with 1dim matrices
         dx = np.array([1, 2, 3, 4, 5])
 
         # test without weights
-        nptest.assert_array_equal(np.array([1, 1, 1, 1, -4]), operators.div(dx))
+        nptest.assert_array_equal(np.array([1, 1, 1, 1, -4]),
+                                  operators.div(dx))
 
         # test with weights
         weights = {'wx': 2, 'wy': 3, 'wz': 4, 'wt': 2}
-        nptest.assert_array_equal(np.array([2, 2, 2, 2, -8]), operators.div(dx, **weights))
+        nptest.assert_array_equal(np.array([2, 2, 2, 2, -8]),
+                                  operators.div(dx, **weights))
 
         # test with 2dim matrices
         dx = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
@@ -254,7 +260,8 @@ class OperatorsTestCase(unittest.TestCase):
         xyz_mat_w = np.array([[[9, 86, 55], [15, 61, -1], [12, 27, -66]],
                               [[34, 81, 20], [29, 45, -47], [15, 0, -123]],
                               [[41, 58, -33], [25, 11, -111], [0, -45, -198]]])
-        nptest.assert_array_equal(xyz_mat_w, operators.div(dx, dy, dz, **weights))
+        nptest.assert_array_equal(xyz_mat_w, operators.div(dx, dy, dz,
+                                                           **weights))
 
         # test with 4d matrices (3x3x3x3)
         dx = np.array([[[[1, 28, 55], [10, 37, 64], [19, 46, 73]],
@@ -344,7 +351,8 @@ class OperatorsTestCase(unittest.TestCase):
                                [[[55, 230, 243], [90, 139, 26], [17, -60, -299]],
                                 [[41, 133, 63], [45, 11, -185], [-59, -219, -541]],
                                 [[18, 27, -126], [-9, -126, -405], [-144, -387, -792]]]])
-        nptest.assert_array_equal(xyzt_mat_w, operators.div(dx, dy, dz, dt, **weights))
+        nptest.assert_array_equal(xyzt_mat_w, operators.div(dx, dy, dz, dt,
+                                                            **weights))
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(OperatorsTestCase)

--- a/pyunlocbox/tests/test_operators.py
+++ b/pyunlocbox/tests/test_operators.py
@@ -24,25 +24,25 @@ class OperatorsTestCase(unittest.TestCase):
         mat5d = mat5d.transpose((3, 4, 2, 1, 0))
 
         # 1D without weights.
-        dx = operators.grad1d(mat1d)
+        dx = operators.grad(mat1d, dim=1)
         nptest.assert_array_equal(np.array([1, 1, 1, 1, 0]), dx)
 
         # 2D without weights.
         mat_dx = np.array([[20, -2, 4, 4], [0, 0, 0, 0]])
         mat_dy = np.array([[1, -3, 1, 0], [-21, 3, 1, 0]])
-        dx, dy = operators.grad2d(mat2d)
+        dx, dy = operators.grad(mat2d, dim=2)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
 
         # 2D with weights.
-        dx, dy = operators.grad2d(mat2d, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy = operators.grad(mat2d, wx=2, wy=0.5, wz=3, wt=2, dim=2)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         nptest.assert_array_equal(mat_dx_w, dx)
         nptest.assert_array_equal(mat_dy_w, dy)
 
         # 3D without weights.
-        dx = operators.grad1d(mat3d)
+        dx = operators.grad(mat3d, dim=1)
         mat_dx = np.array([[[3, 3], [3, 3], [3, 3]],
                            [[0, 0], [0, 0], [0, 0]]])
         mat_dy = np.array([[[1, 1], [1, 1], [0, 0]],
@@ -50,16 +50,16 @@ class OperatorsTestCase(unittest.TestCase):
         mat_dz = np.array([[[6, 0], [6, 0], [6, 0]],
                            [[6, 0], [6, 0], [6, 0]]])
         nptest.assert_array_equal(mat_dx, dx)
-        dx, dy = operators.grad2d(mat3d)
+        dx, dy = operators.grad(mat3d, dim=2)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
-        dx, dy, dz = operators.grad3d(mat3d)
+        dx, dy, dz = operators.grad(mat3d, dim=3)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
 
         # 3D with weights.
-        dx, dy, dz = operators.grad3d(mat3d, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy, dz = operators.grad(mat3d, wx=2, wy=0.5, wz=3, wt=2, dim=3)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         mat_dz_w = mat_dz * 3
@@ -92,23 +92,23 @@ class OperatorsTestCase(unittest.TestCase):
                            [[[12, 0], [12, 0]],
                             [[12, 0], [12, 0]],
                             [[12, 0], [12, 0]]]])
-        dx = operators.grad1d(mat4d)
+        dx = operators.grad(mat4d, dim=1)
         nptest.assert_array_equal(mat_dx, dx)
-        dx, dy = operators.grad2d(mat4d)
+        dx, dy = operators.grad(mat4d, dim=2)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
-        dx, dy, dz = operators.grad3d(mat4d)
+        dx, dy, dz = operators.grad(mat4d, dim=3)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
-        dx, dy, dz, dt = operators.grad4d(mat4d)
+        dx, dy, dz, dt = operators.grad(mat4d, dim=4)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
         nptest.assert_array_equal(mat_dt, dt)
 
         # 4D with weights.
-        dx, dy, dz, dt = operators.grad4d(mat4d, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy, dz, dt = operators.grad(mat4d, wx=2, wy=0.5, wz=3, wt=2, dim=4)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         mat_dz_w = mat_dz * 3
@@ -167,23 +167,23 @@ class OperatorsTestCase(unittest.TestCase):
                             [[[12, 12], [0, 0]],
                              [[12, 12], [0, 0]],
                              [[12, 12], [0, 0]]]]])
-        dx = operators.grad1d(mat5d)
+        dx = operators.grad(mat5d, dim=1)
         nptest.assert_array_equal(mat_dx, dx)
-        dx, dy = operators.grad2d(mat5d)
+        dx, dy = operators.grad(mat5d, dim=2)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
-        dx, dy, dz = operators.grad3d(mat5d)
+        dx, dy, dz = operators.grad(mat5d, dim=3)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
-        dx, dy, dz, dt = operators.grad4d(mat5d)
+        dx, dy, dz, dt = operators.grad(mat5d, dim=4)
         nptest.assert_array_equal(mat_dx, dx)
         nptest.assert_array_equal(mat_dy, dy)
         nptest.assert_array_equal(mat_dz, dz)
         nptest.assert_array_equal(mat_dt, dt)
 
         # 5D with weights.
-        dx, dy, dz, dt = operators.grad4d(mat5d, wx=2, wy=0.5, wz=3, wt=2)
+        dx, dy, dz, dt = operators.grad(mat5d, wx=2, wy=0.5, wz=3, wt=2, dim=4)
         mat_dx_w = mat_dx * 2
         mat_dy_w = mat_dy * 0.5
         mat_dz_w = mat_dz * 3

--- a/pyunlocbox/tests/test_solvers.py
+++ b/pyunlocbox/tests/test_solvers.py
@@ -8,7 +8,7 @@ Test suite for the solvers module of the pyunlocbox package.
 import unittest
 import numpy as np
 import numpy.testing as nptest
-from pyunlocbox import functions, solvers
+from pyunlocbox import functions, solvers, acceleration
 
 
 class FunctionsTestCase(unittest.TestCase):
@@ -17,6 +17,14 @@ class FunctionsTestCase(unittest.TestCase):
         """
         Test some features of the solving function.
         """
+
+        """
+        We have to set a seed here for the random draw if we are required
+        below to assert that the number of iterations of the solvers are equal
+        to some specific values. Otherwise, we get trivial errors when x0 is a
+        little farther away from y in a given draw.
+        """
+        np.random.seed(0)
         y = 5 - 10 * np.random.uniform(size=(15, 4))
 
         def x0(): return np.zeros(y.shape)
@@ -74,21 +82,21 @@ class FunctionsTestCase(unittest.TestCase):
         self.assertEqual(r['crit'], 'DTOL')
         err = np.abs(np.sum(r['objective'][-1]) - np.sum(r['objective'][-2]))
         self.assertLess(err, tol)
-        self.assertEqual(r['niter'], 14)
+        self.assertEqual(r['niter'], 13)
         tol = .1
         r = solvers.solve([f], x0(), None, None, None, tol, None, None, 'NONE')
         self.assertEqual(r['crit'], 'RTOL')
         err = np.abs(np.sum(r['objective'][-1]) - np.sum(r['objective'][-2]))
         err /= np.sum(r['objective'][-1])
         self.assertLess(err, tol)
-        self.assertEqual(r['niter'], 14)
+        self.assertEqual(r['niter'], 35)
         tol = 1e-4
         r = solvers.solve([f], x0(), None, None, None, None, tol, None, 'NONE')
         self.assertEqual(r['crit'], 'XTOL')
         r2 = solvers.solve([f], x0(), maxit=r['niter'] - 1, **nverb)
         err = np.linalg.norm(r['sol'] - r2['sol']) / np.sqrt(x0().size)
         self.assertLess(err, tol)
-        self.assertEqual(r['niter'], 12)
+        self.assertEqual(r['niter'], 10)
         nit = 15
         r = solvers.solve([f], x0(), None, None, None, None, None, nit, 'NONE')
         self.assertEqual(r['crit'], 'MAXIT')
@@ -105,102 +113,30 @@ class FunctionsTestCase(unittest.TestCase):
         self.assertIsInstance(ret['time'], float)
         self.assertIsInstance(ret['objective'], list)
 
-    def test_forward_backward_fista(self):
+    def test_forward_backward(self):
         """
-        Test FISTA algorithm of forward-backward solver with L1-norm, L2-norm
-        and dummy functions.
+        Test forward-backward splitting algorithm without acceleration, and
+        with L1-norm, L2-norm, and dummy functions.
         """
-        y = [4, 5, 6, 7]
-        solver = solvers.forward_backward(method='FISTA')
-        param = {'solver': solver, 'atol': 1e-5, 'verbosity': 'NONE'}
+        y = [4., 5., 6., 7.]
+        solver = solvers.forward_backward(accel=acceleration.dummy())
+        param = {'solver': solver, 'rtol': 1e-6, 'verbosity': 'NONE'}
 
         # L2-norm prox and dummy gradient.
         f1 = functions.norm_l2(y=y)
         f2 = functions.dummy()
-        sol = [3.99996922, 4.99996153, 5.99995383, 6.99994614]
         ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'ATOL')
-        self.assertEqual(ret['niter'], 10)
-
-        # Dummy prox and L2-norm gradient.
-        f1 = functions.dummy()
-        f2 = functions.norm_l2(y=y, lambda_=0.6)
-        sol = [3.99867319, 4.99834148, 5.99800978, 6.99767808]
-        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'ATOL')
-        self.assertEqual(ret['niter'], 10)
-
-        # L2-norm prox and L2-norm gradient.
-        f1 = functions.norm_l2(y=y)
-        f2 = functions.norm_l2(y=y)
-        sol = [3.99904855, 4.99881069, 5.99857282, 6.99833496]
-        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'MAXIT')
-
-        # L1-norm prox and dummy gradient.
-        f1 = functions.norm_l1(y=y)
-        f2 = functions.dummy()
-        sol = y
-        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'ATOL')
-        self.assertEqual(ret['niter'], 6)
-
-        # Dummy prox and L1-norm gradient. As L1-norm possesses no gradient,
-        # the algorithm exchanges the functions : exact same solution.
-        f1 = functions.dummy()
-        f2 = functions.norm_l1(y=y)
-        sol = y
-        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'ATOL')
-        self.assertEqual(ret['niter'], 6)
-
-        # L1-norm prox and L1-norm gradient. L1-norm possesses no gradient.
-        f1 = functions.norm_l1(y=y)
-        f2 = functions.norm_l1(y=y)
-        self.assertRaises(ValueError, solvers.solve,
-                          [f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
+        self.assertEqual(ret['niter'], 35)
 
         # L1-norm prox and L2-norm gradient.
         f1 = functions.norm_l1(y=y, lambda_=1.0)
         f2 = functions.norm_l2(y=y, lambda_=0.8)
-        sol = y
         ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'ATOL')
+        nptest.assert_allclose(ret['sol'], y)
+        self.assertEqual(ret['crit'], 'RTOL')
         self.assertEqual(ret['niter'], 4)
-
-    def test_forward_backward_ista(self):
-        """
-        Test ISTA algorithm of forward-backward solver with L1-norm, L2-norm
-        and dummy functions. Test the effect of step and lambda parameters.
-        """
-        y = [4, 5, 6, 7]
-        # Smaller step size and update rate --> slower convergence.
-        solver = solvers.forward_backward(method='ISTA', step=.8, lambda_=.5)
-        param = {'solver': solver, 'atol': 1e-5, 'verbosity': 'NONE'}
-
-        # L2-norm prox and dummy gradient.
-        f1 = functions.norm_l2(y=y)
-        f2 = functions.dummy()
-        sol = [3.99915094, 4.99893867, 5.9987264, 6.99851414]
-        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'ATOL')
-        self.assertEqual(ret['niter'], 23)
-
-        # L1-norm prox and L2-norm gradient.
-        f1 = functions.norm_l1(y=y, lambda_=1.0)
-        f2 = functions.norm_l2(y=y, lambda_=0.8)
-        sol = [3.99999825, 4.9999979, 5.99999756, 6.99999723]
-        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
-        nptest.assert_allclose(ret['sol'], sol)
-        self.assertEqual(ret['crit'], 'ATOL')
-        self.assertEqual(ret['niter'], 21)
 
     def test_douglas_rachford(self):
         """
@@ -308,32 +244,64 @@ class FunctionsTestCase(unittest.TestCase):
         y = [1, 0, 0.1, 8, -6.5, 0.2, 0.004, 0.01]
         sol = [0.75, 0, 0, 7.75, -6.25, 0, 0, 0]
         w1, w2 = .8, .4
-        f1 = functions.norm_l2(y=y, lambda_=w1/2.)  # Smooth.
-        f2 = functions.norm_l1(lambda_=w2/2.)       # Non-smooth.
-        # f3 = functions.proj_b2(epsilon=0.6)         # Non-smooth.
+        f1 = functions.norm_l2(y=y, lambda_=w1 / 2.)  # Smooth.
+        f2 = functions.norm_l1(lambda_=w2 / 2.)       # Non-smooth.
 
         # Solvers.
         L = w1  # Lipschitz continuous gradient.
-        params = {'step': 1./L, 'lambda_': 0.5}
+        step = 1. / L
+        lambda_ = 0.5
+        params = {'step': step, 'lambda_': lambda_}
         slvs = []
-        slvs.append(solvers.forward_backward(method='ISTA', **params))
-        slvs.append(solvers.forward_backward(method='FISTA', **params))
+        slvs.append(solvers.forward_backward(accel=acceleration.dummy(),
+                                             step=step))
         slvs.append(solvers.douglas_rachford(**params))
         slvs.append(solvers.generalized_forward_backward(**params))
-        # slvs.append(solvers.mlfbf(step=.7/L))  # TODO
-        slvs.append(solvers.projection_based(step=1e-3))
 
         # Compare solutions.
         params = {'rtol': 1e-14, 'verbosity': 'NONE', 'maxit': 1e4}
-        niters = [26, 2, 61, 26, 1e4]
+        niters = [2, 61, 26]
         for solver, niter in zip(slvs, niters):
             x0 = np.zeros(len(y))
             ret = solvers.solve([f1, f2], x0, solver, **params)
-            # These primal-dual solvers are much slower.
-            if type(solver) is solvers.projection_based:
-                nptest.assert_allclose(ret['sol'], sol, atol=0.2)
+            nptest.assert_allclose(ret['sol'], sol)
+            self.assertEqual(ret['niter'], niter)
+            self.assertIs(ret['sol'], x0)  # The initial value was modified.
+
+    def test_primal_dual_solver_comparison(self):
+        """
+        Test that all primal-dual solvers return the same and correct solution.
+
+        I had to create this separate function because the primal-dual solvers
+        were too slow for the problem above.
+        """
+
+        # Convex functions.
+        y = np.array([294, 390, 361])
+        sol = [1., 1., 1.]
+        L = np.array([[5, 9, 3], [7, 8, 5], [4, 4, 9], [0, 1, 7]])
+        f1 = functions.norm_l1(y=y)
+        f2 = functions.norm_l1()
+        f3 = functions.dummy()
+
+        # Solvers.
+        step = 0.5 / (1 + np.linalg.norm(L, 2))
+        slvs = []
+        slvs.append(solvers.mlfbf(step=step))
+        slvs.append(solvers.projection_based(step=step))
+
+        # Compare solutions.
+        params = {'rtol': 0, 'verbosity': 'NONE', 'maxit': 50}
+        niters = [50, 50]
+        for solver, niter in zip(slvs, niters):
+            x0 = np.zeros(len(y))
+
+            if type(solver) is solvers.mlfbf:
+                ret = solvers.solve([f1, f2, f3], x0, solver, **params)
             else:
-                nptest.assert_allclose(ret['sol'], sol)
+                ret = solvers.solve([f1, f2], x0, solver, **params)
+
+            nptest.assert_allclose(ret['sol'], sol)
             self.assertEqual(ret['niter'], niter)
             self.assertIs(ret['sol'], x0)  # The initial value was modified.
 

--- a/pyunlocbox/tests/test_solvers.py
+++ b/pyunlocbox/tests/test_solvers.py
@@ -18,14 +18,13 @@ class FunctionsTestCase(unittest.TestCase):
         Test some features of the solving function.
         """
 
-        """
-        We have to set a seed here for the random draw if we are required
-        below to assert that the number of iterations of the solvers are equal
-        to some specific values. Otherwise, we get trivial errors when x0 is a
-        little farther away from y in a given draw.
-        """
-        np.random.seed(0)
-        y = 5 - 10 * np.random.uniform(size=(15, 4))
+        # We have to set a seed here for the random draw if we are required
+        # below to assert that the number of iterations of the solvers are
+        # equal to some specific values. Otherwise, we get trivial errors when
+        # x0 is a little farther away from y in a given draw.
+        rs = np.random.RandomState(42)
+
+        y = 5 - 10 * rs.uniform(size=(15, 4))
 
         def x0(): return np.zeros(y.shape)
         nverb = {'verbosity': 'NONE'}

--- a/pyunlocbox/tests/test_solvers.py
+++ b/pyunlocbox/tests/test_solvers.py
@@ -126,6 +126,25 @@ class FunctionsTestCase(unittest.TestCase):
         self.assertRaises(NotImplementedError, s._algo)
         self.assertRaises(NotImplementedError, s.post)
 
+    def test_gradient_descent(self):
+        """
+        Test gradient descent solver with l2-norms in the objective.
+        """
+        y = [4., 5., 6., 7.]
+        A = np.array([[1., 1., 1., 0.], [0., 1., 1., 1.], [0., 1., 0., 0.],
+                      [1., 0., 0., 1.]])
+        sol = np.array([0.28846154,  0.11538462,  1.23076923,  1.78846154])
+        step = 0.5 / (np.linalg.norm(A) + 1.)
+        solver = solvers.gradient_descent(step=step)
+        param = {'solver': solver, 'rtol': 0, 'verbosity': 'NONE'}
+
+        f1 = functions.norm_l2(y=y)
+        f2 = functions.norm_l2(A=A)
+        ret = solvers.solve([f1, f2], np.zeros(len(y)), **param)
+        nptest.assert_allclose(ret['sol'], sol)
+        self.assertEqual(ret['crit'], 'MAXIT')
+        self.assertEqual(ret['niter'], 200)
+
     def test_forward_backward(self):
         """
         Test forward-backward splitting algorithm without acceleration, and

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='pyunlocbox',
-    version='0.2.2',
+    version='0.2.3',
     description='A convex optimization toolbox using proximal '
                 'splitting methods.',
     long_description=open('README.rst').read(),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='pyunlocbox',
-    version='0.2.3',
+    version='0.3',
     description='A convex optimization toolbox using proximal '
                 'splitting methods.',
     long_description=open('README.rst').read(),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='pyunlocbox',
-    version='0.3',
+    version='0.3.0',
     description='A convex optimization toolbox using proximal '
                 'splitting methods.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
Created new module for implementing acceleration schemes to our solvers. 

Changes in pyunlocbox.solvers:
- Implement standard gradient descent (for completeness and for use with acceleration schemes).
- Change the implementation of FISTA/ISTA. There's only the forward_backward solver, but the FISTA acceleration scheme is passed by an acceleration object.

Additions in pyunlocbox.acceleration:
- A default acceleration object modeled after the solver object. It serves as a parent class, and to guide the design of the rest of the acceleration schemes.
- A dummy acceleration scheme. It does nothing and is there only to maintain the default behavior of the solvers in the toolbox.
- A backtracking strategy to update the step size of the descent steps in the solvers. It is based on a local quadratic approximation of the objective, and it's the same used in the original FISTA paper.
- The FISTA acceleration scheme, which consists in taking a linear combination of previous iterates to boost the solution towards the minimum of the objective.
- A combination of the FISTA acceleration with the backtracking strategy.
- The regularized nonlinear acceleration (RNA) of [Scieur et al. 2016] for gradient descent schemes.

Finally, I've updated the documentation and added tests for each new feature. I had to remove support to Python 3.3 because matplotlib does not support it anymore. On the other hand, I've added support to Python 3.6. The current version of Sphinx has trouble dealing with .svg images for the LaTeX documents, so the badges with this extension are only included in the HTML docs.