### PR TITLE
ENH: Proposed refactoring of the grad operator

### DIFF
--- a/pyunlocbox/operators.py
+++ b/pyunlocbox/operators.py
@@ -42,77 +42,25 @@ def grad(x, dim=2, **kwargs):
 
     """
 
-    axis = 0
-    while axis < len(x.shape):
-        if axis >= 0:
-            try:
-                zero_dx = np.zeros((np.append(np.shape(zero_dx),
-                                              np.shape(x)[axis])))
-            except NameError:
-                zero_dx = np.zeros((1))
-        if axis >= 1:
-            try:
-                zero_dy = np.zeros((np.append(np.shape(zero_dy),
-                                              np.shape(x)[axis])))
-            except NameError:
-                zero_dy = np.zeros((np.shape(x)[0], 1))
-        if axis >= 2:
-            try:
-                zero_dz = np.zeros((np.append(np.shape(zero_dz),
-                                              np.shape(x)[axis])))
-            except NameError:
-                zero_dz = np.zeros((np.shape(x)[0], np.shape(x)[1], 1))
-        if axis >= 3:
-            try:
-                zero_dt = np.zeros((np.append(np.shape(zero_dt),
-                                              np.shape(x)[axis])))
-            except NameError:
-                zero_dt = np.zeros((np.shape(x)[0], np.shape(x)[1],
-                                    np.shape(x)[2], 1))
-        axis += 1
+    WEIGHT_KEYS = ("wx", "wy", "wz", "wt")
+    diffs = []
+    for axis in range(dim):
+        zeros_shape = list(x.shape)
+        zeros_shape[axis] = 1
 
-    if dim >= 1:
-        dx = np.concatenate((x[1:, ] - x[:-1, ], zero_dx), axis=0)
+        diff = np.concatenate((np.diff(x, axis=axis),
+                               np.zeros(zeros_shape)),
+                              axis=axis)
         try:
-            dx *= kwargs["wx"]
+            diff *= kwargs[WEIGHT_KEYS[axis]]
         except (KeyError, TypeError):
             pass
-
-    if dim >= 2:
-        dy = np.concatenate((x[:, 1:, ] - x[:, :-1, ], zero_dy), axis=1)
-        try:
-            dy *= kwargs["wy"]
-        except (KeyError, TypeError):
-            pass
-
-    if dim >= 3:
-        dz = np.concatenate((x[:, :, 1:, ] - x[:, :, :-1, ], zero_dz),
-                            axis=2)
-        try:
-            dz *= kwargs["wz"]
-        except (KeyError, TypeError):
-            pass
-
-    if dim >= 4:
-        dt = np.concatenate((x[:, :, :, 1:, ] - x[:, :, :, :-1, ],
-                             zero_dt),
-                            axis=3)
-        try:
-            dt *= kwargs["wt"]
-        except (KeyError, TypeError):
-            pass
+        diffs.append(diff)
 
     if dim == 1:
-        return dx
-
-    elif dim == 2:
-        return dx, dy
-
-    elif dim == 3:
-        return dx, dy, dz
-
-    elif dim == 4:
-        return dx, dy, dz, dt
+        return diffs[0]
+    else:
+        return diffs
 
 
 def div(*args, **kwargs):


### PR DESCRIPTION
The `operators.grad` function has been refactored by using `numpy.diff`
and zero-padding by using `numpy.zeros` a bit more cleverly.
In addition, this generalises the `grad` function to any number of
dimensions (`dim`) instead of maximum 4.
It makes the function a slight bit slower. My benchmarking indicates
about 1% slower for arrays with 10 million entries. The relative
degradation may be slightly worse for smaller arrays.