### PR TITLE
FEAT: add structured_sparsity function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ To compose your objective, the following functions are included:
 * TV-norm (eval, prox)
 * Projection on the positive octant (eval, prox)
 * Projection on the L2-ball (eval, prox)
+* Structured Sparsity (eval, prox)
 
 Alternatively, you can easily define a custom function by implementing an
 evaluation method and a proximal operator or gradient method:

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ To compose your objective, the following functions are included:
 * TV-norm (eval, prox)
 * Projection on the positive octant (eval, prox)
 * Projection on the L2-ball (eval, prox)
-* Structured Sparsity (eval, prox)
+* Structured sparsity (eval, prox)
 
 Alternatively, you can easily define a custom function by implementing an
 evaluation method and a proximal operator or gradient method:

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -8,6 +8,7 @@ Unreleased
 * Drop support of Python 3.4 and test with 3.7. Last version to support 2.7.
 * Merged all the extra requirements in a single dev requirement.
 * Addition of the proj_positive function
+* Addition of the structured_sparsity function.
 
 0.5.2 (2017-12-15)
 ------------------

--- a/pyunlocbox/functions.py
+++ b/pyunlocbox/functions.py
@@ -42,6 +42,7 @@ Then, derived classes implement various common objective functions.
 .. autosummary::
 
     dummy
+    structured_sparsity
 
 .. inheritance-diagram:: pyunlocbox.functions
     :parts: 2
@@ -990,3 +991,75 @@ class proj_b2(proj):
                                               niter))
 
         return sol
+
+
+class structured_sparsity(func):
+    r"""
+    Structured Sparsity term (eval, prox).
+
+    This class implements the structured sparsity term that is defined in the
+    work of Jenatton et al. 2011 "Proximal methods for hierachical sparse
+    coding" (https://hal.inria.fr/inria-00516723).
+
+    .. math:: \Omega(x) = \lambda \cdot \sum_{g\in G}w_g\cdot \|x_g\|_2
+
+    Parameters
+    ----------
+    lam: float,
+        The scaling factor of the function that corresponds to :math:`\lambda`.
+        Must be a float greater or equal than zero.
+    groups: list of lists
+        Each element encodes the indices of the vector belonging to a single
+        group. Corresponds to :math:`G`.
+    weights: iterable
+        Weight associated to each group. Corresponds to :math:`w_g`. Must have
+        the same length as :math:`G`.
+
+    Examples
+    --------
+    >>> from pyunlocbox import functions
+    >>> lam = 10.0
+    >>> gg = [[0, 1], [3, 2, 4]]
+    >>> ww = [2., 1.]
+    >>> f = functions.structured_sparsity(lam=lam, groups=gg, weights=ww)
+    >>> x = [2., 2.5, -0.5, 0.3, 0.01]
+    >>> f.eval(x)
+    69.86305169905782
+    >>> f.prox(x, 0.1)
+    array([0.7506099 , 0.93826238, 0.        , 0.        , 0.        ])
+
+    """
+
+    def __init__(self, lam=1.0, groups=[[]], weights=[0.0], **kwargs):
+        super(structured_sparsity, self).__init__(**kwargs)
+
+        lam = float(lam)
+        if lam < 0:
+            raise ValueError('The lambda scaling factor must be greater or '
+                             'equal than zero.')
+        self._regularization_parameter = lam
+
+        if not isinstance(groups, list):
+            raise TypeError('The groups must be defined as a list of lists.')
+        self._groups = groups
+
+        if len(weights) != len(groups):
+            raise ValueError('Length of weights must be equal to number of '
+                             'groups')
+        self._weights = weights
+
+    def _eval(self, x):
+        costs = [w * np.linalg.norm(x[g])
+                 for g, w in zip(self._groups, self._weights)]
+        return self._regularization_parameter * np.sum(costs)
+
+    def _prox(self, x, mu):
+        v = x.copy()
+        for g, w in zip(self._groups, self._weights):
+            xn = np.linalg.norm(v[g])
+            r = mu * self._regularization_parameter * w
+            if xn > r:
+                v[g] -= v[g] * r / xn
+            else:
+                v[g] = 0.0
+        return v

--- a/pyunlocbox/tests/test_functions.py
+++ b/pyunlocbox/tests/test_functions.py
@@ -439,23 +439,23 @@ class TestCase(unittest.TestCase):
             functions.structured_sparsity(1.0, [[1, 2], [3, 4]], [10.])
 
         # test call of eval and prox
-        x = np.array([0.01, 0.5, 3., 4.])
+        x = np.array([0.01, 0.5, 3, 4])
         groups = [[0, 1], [2, 3]]
-        weights = np.array([10.0, .2])
-        f = functions.structured_sparsity(1.0, groups, weights)
+        weights = np.array([10, .2])
+        f = functions.structured_sparsity(1, groups, weights)
         # test eval
-        eval = f._eval(x)
+        result = f.eval(x)
         gt = (weights[0] * np.linalg.norm(x[groups[0]], 2) +
               weights[1] * np.linalg.norm(x[groups[1]], 2))
-        self.assertAlmostEqual(eval, gt)
+        self.assertAlmostEqual(result, gt)
         # test prox
         gt = x.copy()
         # the first group has norm lower than the corresponding weight
-        gt[groups[0]] = 0.0
+        gt[groups[0]] = 0
         # the second group has norm higher than the corresponding weight
         gt[groups[1]] -= (x[groups[1]] * weights[1] /
                           np.linalg.norm(x[groups[1]]))
-        prox = f._prox(x, 1.0)
+        prox = f.prox(x, 1)
         np.testing.assert_almost_equal(prox, gt)
 
     def test_capabilities(self):

--- a/pyunlocbox/tests/test_functions.py
+++ b/pyunlocbox/tests/test_functions.py
@@ -422,6 +422,42 @@ class TestCase(unittest.TestCase):
         nptest.assert_equal(res[x > 0], x[x > 0])  # Positives are unchanged.
         self.assertEqual(fpos.eval(x), 0)
 
+    def test_structured_sparsity(self):
+        """
+        Test the structured sparsity function.
+
+        """
+        # test init
+        # test parsing of lambda
+        with self.assertRaises(ValueError):
+            functions.structured_sparsity(-1, [[]], [0.0])
+        # test parsing of groups
+        with self.assertRaises(TypeError):
+            functions.structured_sparsity(1.0, 1, [0.0])
+        # test parsing of weights
+        with self.assertRaises(ValueError):
+            functions.structured_sparsity(1.0, [[1, 2], [3, 4]], [10.])
+
+        # test call of eval and prox
+        x = np.array([0.01, 0.5, 3., 4.])
+        groups = [[0, 1], [2, 3]]
+        weights = np.array([10.0, .2])
+        f = functions.structured_sparsity(1.0, groups, weights)
+        # test eval
+        eval = f._eval(x)
+        gt = (weights[0] * np.linalg.norm(x[groups[0]], 2) +
+              weights[1] * np.linalg.norm(x[groups[1]], 2))
+        self.assertAlmostEqual(eval, gt)
+        # test prox
+        gt = x.copy()
+        # the first group has norm lower than the corresponding weight
+        gt[groups[0]] = 0.0
+        # the second group has norm higher than the corresponding weight
+        gt[groups[1]] -= (x[groups[1]] * weights[1] /
+                          np.linalg.norm(x[groups[1]]))
+        prox = f._prox(x, 1.0)
+        np.testing.assert_almost_equal(prox, gt)
+
     def test_capabilities(self):
         """
         Test that a function implements the necessary methods. A function must


### PR DESCRIPTION
This PR adds the `structured_sparsity` class to the ones available at `pyunlocbox.functions`. The corresponding tests are added in the `tests.test_functions.TestCase.test_structured_sparsity` method. The `README.rst` and `doc/history.rst` files are also updated.

For the documentation, I tried to copy the same formatting of the other functions. Hope I did it right. In case I did not, I'll be happy to follow the maintainers' indications.