### PR TITLE
[WIP] replace numpydoc with napoleon?

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,8 +12,9 @@ extensions.append('sphinx.ext.autodoc')
 autodoc_default_flags = ['members', 'undoc-members', 'show-inheritance']
 autodoc_member_order = 'bysource'  # alphabetical, groupwise, bysource
 
-extensions.append('numpydoc')
-numpydoc_show_class_members = False
+extensions.append('sphinx.ext.napoleon')
+napoleon_numpy_docstring = True
+napoleon_use_rtype = False  # rtd-theme doesn't use rtype
 
 extensions.append('matplotlib.sphinxext.plot_directive')
 plot_include_source = True

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
             'coveralls',
             # Dependencies to build the documentation.
             'sphinx',
-            'numpydoc',
             'sphinxcontrib-bibtex',
             'sphinx-rtd-theme',
             'matplotlib',


### PR DESCRIPTION
For some reason function and method parameters are badly displayed. Aren't we following the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html) correctly? Is the RTD theme problematic? One way to solve the issue might be to switch from [numpydoc](https://numpydoc.readthedocs.io) to [napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html), which is maintained by sphinx themselves.

To be applied to the [PyGSP](https://github.com/epfl-lts2/pygsp/) as well to keep them in sync.

Example from [our doc](https://pyunlocbox.readthedocs.io/en/maintenance/reference/functions.html#pyunlocbox.functions.func):
![20200528_160359](https://user-images.githubusercontent.com/6806065/83151486-eb69be80-a0fc-11ea-8884-dbeee785ce05.png)